### PR TITLE
Query scope - extend the functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,11 @@
         "analytic",
         "laravel analytic",
         "php",
-        "kakaprodo"
+        "kakaprodo",
+        "promesse kayenga",
+        "php analytic",
+        "laravel metrics",
+        "php metrics"
     ],
     "autoload": {
         "psr-4": {
@@ -23,8 +27,8 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.0",
-        "laravel/framework": ">=7.0",
+        "php": ">=8.0",
+        "laravel/framework": ">=8.0",
         "kakaprodo/custom-data":">=1.9.5 || dev-develop"
     },
      "extra": {

--- a/src/Console/Stubs/CardCountHandler.php.stub
+++ b/src/Console/Stubs/CardCountHandler.php.stub
@@ -22,7 +22,7 @@ class {class_name} extends CardCount
     /**
      * the column to use as argument of the aggrgate function
      */
-    protected $columnForAggregate = 'amount_column';
+    protected $columnForAggregate = null;
 
     /**
      * any task you want to be executed before any other

--- a/src/Console/Stubs/PieChartHandler.php.stub
+++ b/src/Console/Stubs/PieChartHandler.php.stub
@@ -25,7 +25,7 @@ class {class_name} extends PieChart
      * this coulmn will have the value of 
      * the grouped item.
      */
-    protected $mappingColumnValue = 'column';
+    protected $mappingColumnValue = null;
 
     /**
      * any task you want to be executed before any other

--- a/src/Http/Requests/SystemAnalyticRequest.php
+++ b/src/Http/Requests/SystemAnalyticRequest.php
@@ -33,8 +33,7 @@ class SystemAnalyticRequest extends FormRequest
             'scope_type' => [
                 'bail',
                 Rule::requiredIf($this->isScopeTypeRequired($this->analytic_type)),
-                'string',
-                Rule::in(Util::handlerScopeTypes($this->analytic_type))
+                'string'
             ],
             'scope_value' => [
                 Rule::requiredIf($isFixedScopeType = Util::isFixedScopeType($this->scope_type)),
@@ -68,10 +67,6 @@ class SystemAnalyticRequest extends FormRequest
     public function messages()
     {
         return [
-            'scope_type.in' => 'The scope type is supposed to be one of : ' . implode(
-                ',',
-                Util::handlerScopeTypes($this->analytic_type)
-            ),
             'boolean_scope_type.in'  => 'The boolean scope type is supposed to be one of : ' . implode(
                 ',',
                 Util::getBooleanScopeTypes($this->analytic_type)

--- a/src/Lib/AnalyticHandler.php
+++ b/src/Lib/AnalyticHandler.php
@@ -2,7 +2,6 @@
 
 namespace Kakaprodo\SystemAnalytic\Lib;
 
-use Illuminate\Support\Facades\Cache;
 use Kakaprodo\SystemAnalytic\Lib\Data\AnalyticData;
 use Kakaprodo\SystemAnalytic\Lib\Cache\SystemAnalyticCache;
 use Kakaprodo\SystemAnalytic\Lib\BaseClasses\AnalyticHandlerBase;
@@ -22,6 +21,8 @@ abstract class AnalyticHandler extends AnalyticHandlerBase
     public static function handler(AnalyticData $data)
     {
         $analytic = new static($data);
+
+        $analytic->processPlugins();
 
         $cachedResult = $analytic->cache()->getCachedResultIfExists();
 

--- a/src/Lib/BaseClasses/AnalyticFilterHubBase.php
+++ b/src/Lib/BaseClasses/AnalyticFilterHubBase.php
@@ -18,6 +18,16 @@ abstract class AnalyticFilterHubBase
      */
     protected $initialScopeColumn;
 
+    /**
+     * Package Default scopes handlers 
+     */
+    protected $defaultScopeHandlers = [];
+
+    /**
+     * Plugin(or custom) scope handlers
+     */
+    protected $customScopeHandlers = [];
+
     const TYPE_YEAR_AGO = 'year_ago';
     const TYPE_TODAY = 'today';
     const TYPE_MONTH_AGO = 'month_ago';
@@ -50,102 +60,64 @@ abstract class AnalyticFilterHubBase
 
     public function __construct(AnalyticData &$data)
     {
-        $this->data = $data;
+        $this->data = &$data;
     }
 
+    /**
+     * call the appropraite callback(or handler) of a given
+     * scope
+     */
     public function applyFilter($query)
     {
-        $filterHandlers =  $this->getFilterHandlers($query)[$this->data->scope_type] ?? null;
+        $scopes = $this->getFilterHandlers($query);
+        $filterHandlers = $scopes[$this->data->scope_type] ?? null;
 
         return Util::callFunction(
             $filterHandlers,
-            'Un-supported filter type: ' . $this->data->scope_type
+            "The scope type is supposed to be one of: " . implode(',', array_keys($scopes))
         );
     }
 
+    /**
+     * combine default scopes with custom(plugin) scopes
+     */
     public function getFilterHandlers($query)
     {
-        $filterHandlers =  [
-            self::TYPE_TODAY => function () use ($query) {
-                return $this->filterByToday($query);
-            },
-            self::TYPE_WEEK_AGO => function () use ($query) {
-                return $this->filterByWeekAgo($query);
-            },
-            self::TYPE_MONTH_AGO => function () use ($query) {
-                return $this->filterByMonthAgo($query);
-            },
-            self::TYPE_YEAR_AGO =>  function () use ($query) {
-                return $this->filterByYearAgo($query);
-            },
+        $this->defaultScopeHandlers =  [
+            self::TYPE_TODAY => fn () => $this->filterByToday($query),
+            self::TYPE_WEEK_AGO => fn () => $this->filterByWeekAgo($query),
+            self::TYPE_MONTH_AGO => fn () => $this->filterByMonthAgo($query),
+            self::TYPE_YEAR_AGO =>  fn () => $this->filterByYearAgo($query),
 
-            self::TYPE_THIS_WEEK => function () use ($query) {
-                return $this->filterByThisWeek($query);
-            },
-            self::TYPE_THIS_MONTH => function () use ($query) {
-                return $this->filterByThisMonth($query);
-            },
-            self::TYPE_THIS_YEAR => function () use ($query) {
-                return $this->filterByThisYear($query);
-            },
+            self::TYPE_THIS_WEEK => fn () =>  $this->filterByThisWeek($query),
+            self::TYPE_THIS_MONTH => fn () => $this->filterByThisMonth($query),
+            self::TYPE_THIS_YEAR => fn () => $this->filterByThisYear($query),
 
-            self::TYPE_LAST_WEEK => function () use ($query) {
-                return $this->filterByLastWeek($query);
-            },
-            self::TYPE_LAST_MONTH => function () use ($query) {
-                return $this->filterByLastMonth($query);
-            },
-            self::TYPE_LAST_YEAR => function () use ($query) {
-                return $this->filterByLastYear($query);
-            },
+            self::TYPE_LAST_WEEK => fn () => $this->filterByLastWeek($query),
+            self::TYPE_LAST_MONTH => fn () => $this->filterByLastMonth($query),
+            self::TYPE_LAST_YEAR => fn () => $this->filterByLastYear($query),
 
-            self::TYPE_FIXED_HOUR => function () use ($query) {
-                return $this->filterByFixedHour($query);
-            },
-            self::TYPE_FIXED_DATE => function () use ($query) {
-                return $this->filterByFixedDate($query);
-            },
-            self::TYPE_FIXED_MONTH => function () use ($query) {
-                return $this->filterByFixedMonth($query);
-            },
-            self::TYPE_FIXED_YEAR => function () use ($query) {
-                return $this->filterByFixedYear($query);
-            },
+            self::TYPE_FIXED_HOUR => fn () => $this->filterByFixedHour($query),
+            self::TYPE_FIXED_DATE => fn () => $this->filterByFixedDate($query),
+            self::TYPE_FIXED_MONTH => fn () => $this->filterByFixedMonth($query),
+            self::TYPE_FIXED_YEAR => fn () => $this->filterByFixedYear($query),
 
-            self::TYPE_RANGE_HOUR => function () use ($query) {
-                return $this->filterByRangeHour($query);
-            },
-            self::TYPE_RANGE_DATE => function () use ($query) {
-                return $this->filterByRangeDate($query);
-            },
-            self::TYPE_RANGE_MONTH => function () use ($query) {
-                return $this->filterByRangeMonth($query);
-            },
-            self::TYPE_RANGE_YEAR => function () use ($query) {
-                return $this->filterByRangeYear($query);
-            },
+            self::TYPE_RANGE_HOUR => fn () => $this->filterByRangeHour($query),
+            self::TYPE_RANGE_DATE => fn () => $this->filterByRangeDate($query),
+            self::TYPE_RANGE_MONTH => fn () => $this->filterByRangeMonth($query),
+            self::TYPE_RANGE_YEAR => fn () => $this->filterByRangeYear($query),
 
-            self::FIRST_QUARTER => function () use ($query) {
-                return $this->filterByFirstQuarter($query);
-            },
-            self::SECOND_QUARTER => function () use ($query) {
-                return $this->filterBySecondQuarter($query);
-            },
-            self::THIRD_QUARTER => function () use ($query) {
-                return $this->filterByThirdQuarter($query);
-            },
-            self::FOURTH_QUARTER => function () use ($query) {
-                return $this->filterByFourthQuarter($query);
-            },
+            self::FIRST_QUARTER => fn () => $this->filterByFirstQuarter($query),
+            self::SECOND_QUARTER => fn () => $this->filterBySecondQuarter($query),
+            self::THIRD_QUARTER => fn () => $this->filterByThirdQuarter($query),
+            self::FOURTH_QUARTER => fn () => $this->filterByFourthQuarter($query),
 
-            self::TYPE_ALL => function () use ($query) {
-                return $query;
-            }
+            self::TYPE_ALL => fn () => $query
         ];
 
-        $scopePlugins = optional($this->data->pluginHub->scopes)->load() ?? [];
+        $this->customScopeHandlers = $this->data->pluginHub->scopes?->load($query) ?? [];
 
-        return array_merge($filterHandlers, $scopePlugins);
+        return array_merge($this->defaultScopeHandlers, $this->customScopeHandlers);
     }
 
     /**

--- a/src/Lib/BaseClasses/AnalyticFilterHubBase.php
+++ b/src/Lib/BaseClasses/AnalyticFilterHubBase.php
@@ -69,12 +69,15 @@ abstract class AnalyticFilterHubBase
      */
     public function applyFilter($query)
     {
-        $filterHandlers = $this->getDefaultScopes($query)[$this->data->scope_type]
-            ?? $this->getPluginScopes($query)[$this->data->scope_type]
-            ?? null;
+        $filterHandler = $this->getDefaultScopes($query)[$this->data->scope_type] ?? null;
+
+        if (!$filterHandler) {
+            $filterHandler = $this->getPluginScopes($query)[$this->data->scope_type] ?? null;
+            $this->data->scopeHandlerIsFromPlugin =  $filterHandler != null;
+        }
 
         return Util::callFunction(
-            $filterHandlers,
+            $filterHandler,
             "The scope type is supposed to be one of: " . implode(',', array_keys(
                 array_merge($this->defaultScopeHandlers, $this->customScopeHandlers)
             ))

--- a/src/Lib/BaseClasses/AnalyticHandlerBase.php
+++ b/src/Lib/BaseClasses/AnalyticHandlerBase.php
@@ -132,11 +132,11 @@ abstract class AnalyticHandlerBase
      */
     protected $shouldForceScopeType = true;
 
-    public function __construct(AnalyticData $data)
+    public function __construct(AnalyticData &$data)
     {
-        $this->data = $data;
-        $this->shouldExport = $data->should_export;
-        $this->exportFile = $data->file_type;
+        $this->data = &$data;
+        $this->shouldExport = $this->data->should_export;
+        $this->exportFile = $this->data->file_type;
     }
 
     /**

--- a/src/Lib/BaseClasses/AnalyticHandlerBase.php
+++ b/src/Lib/BaseClasses/AnalyticHandlerBase.php
@@ -13,6 +13,7 @@ use Kakaprodo\SystemAnalytic\Lib\BaseClasses\Traits\HasRegisteredPluginClass;
 use Kakaprodo\SystemAnalytic\Lib\Validation\HasAnalyticInterfaceValidationTrait;
 use Kakaprodo\SystemAnalytic\Lib\BaseClasses\Traits\HasGeneralHandlerHelperTrait;
 use Kakaprodo\SystemAnalytic\Lib\BaseClasses\Traits\HasInterfacePlaceholderMethods;
+use Kakaprodo\SystemAnalytic\Lib\Plugins\PluginHub;
 
 abstract class AnalyticHandlerBase
 {
@@ -168,10 +169,30 @@ abstract class AnalyticHandlerBase
         return Util::classToKebak(static::class);
     }
 
-
+    /**
+     * Validate class interfaces
+     */
     protected function validateProperties()
     {
         $this->validateHandlerInterface($this);
+
+        return $this;
+    }
+
+    /**
+     * Load global and local plugin to the current handler
+     */
+    protected function processPlugins()
+    {
+        $pluginHub = $this->plugin();
+
+        $handlerRegister = $this->data->handlerRegisterData();
+
+        if (method_exists($handlerRegister, 'loadPlugins')) {
+            $handlerRegister->loadPlugins($pluginHub);
+        }
+
+        $this->loadPlugins($pluginHub);
 
         return $this;
     }
@@ -330,5 +351,12 @@ abstract class AnalyticHandlerBase
     public function withResponse(): array
     {
         return [];
+    }
+
+    /**
+     * method in which to load plugins
+     */
+    protected function loadPlugins(PluginHub $pluginHub)
+    {
     }
 }

--- a/src/Lib/BaseClasses/AnalyticHandlerBase.php
+++ b/src/Lib/BaseClasses/AnalyticHandlerBase.php
@@ -6,6 +6,8 @@ use ReflectionClass;
 use Illuminate\Support\Arr;
 use Kakaprodo\SystemAnalytic\Utilities\Util;
 use Kakaprodo\SystemAnalytic\Lib\Data\AnalyticData;
+use Kakaprodo\SystemAnalytic\Lib\Plugins\PluginHub;
+use Kakaprodo\SystemAnalytic\Lib\Cache\SystemAnalyticCache;
 use Kakaprodo\SystemAnalytic\Lib\FilterHub\AnalyticFilterHub;
 use Kakaprodo\SystemAnalytic\Lib\FilterHub\AnalyticBoolFilterHub;
 use Kakaprodo\SystemAnalytic\Lib\BaseClasses\Traits\HasMethodCallingTrait;
@@ -13,7 +15,6 @@ use Kakaprodo\SystemAnalytic\Lib\BaseClasses\Traits\HasRegisteredPluginClass;
 use Kakaprodo\SystemAnalytic\Lib\Validation\HasAnalyticInterfaceValidationTrait;
 use Kakaprodo\SystemAnalytic\Lib\BaseClasses\Traits\HasGeneralHandlerHelperTrait;
 use Kakaprodo\SystemAnalytic\Lib\BaseClasses\Traits\HasInterfacePlaceholderMethods;
-use Kakaprodo\SystemAnalytic\Lib\Plugins\PluginHub;
 
 abstract class AnalyticHandlerBase
 {
@@ -356,5 +357,16 @@ abstract class AnalyticHandlerBase
      */
     protected function loadPlugins(PluginHub $pluginHub)
     {
+    }
+
+    /**
+     * Define when to persit report
+     */
+    public function persistWhen()
+    {
+        // for custom scopes, developer needs to overide this method 
+        if ($this->data->scopeHandlerIsFromPlugin) return false;
+
+        return SystemAnalyticCache::PERSIST_WHEN_SCOPE_IS_INPAST;
     }
 }

--- a/src/Lib/BaseClasses/AnalyticHandlerBase.php
+++ b/src/Lib/BaseClasses/AnalyticHandlerBase.php
@@ -180,7 +180,7 @@ abstract class AnalyticHandlerBase
     }
 
     /**
-     * Load global and local plugin to the current handler
+     * Load global and local plugins to the current handler
      */
     protected function processPlugins()
     {
@@ -188,9 +188,7 @@ abstract class AnalyticHandlerBase
 
         $handlerRegister = $this->data->handlerRegisterData();
 
-        if (method_exists($handlerRegister, 'loadPlugins')) {
-            $handlerRegister->loadPlugins($pluginHub);
-        }
+        $handlerRegister->loadPlugins($pluginHub);
 
         $this->loadPlugins($pluginHub);
 

--- a/src/Lib/BaseClasses/AnalyticPluginBase.php
+++ b/src/Lib/BaseClasses/AnalyticPluginBase.php
@@ -2,6 +2,8 @@
 
 namespace Kakaprodo\SystemAnalytic\Lib\BaseClasses;
 
+use Kakaprodo\SystemAnalytic\Lib\Data\AnalyticData;
+
 
 abstract class AnalyticPluginBase
 {
@@ -9,11 +11,19 @@ abstract class AnalyticPluginBase
      * can be any a class or an array of key:value
      * @var string|array|null
      */
-    public $pluginHandler = [];
+    protected $pluginHandler = [];
 
-    public function __construct($pluginHandler)
+    /**
+     * The inputed data
+     * 
+     * @var AnalyticData
+     */
+    protected $data;
+
+    public function __construct($pluginHandler, AnalyticData &$data)
     {
         $this->pluginHandler = $pluginHandler;
+        $this->data = &$data;
     }
 
     /**

--- a/src/Lib/BaseClasses/AnalyticPluginBase.php
+++ b/src/Lib/BaseClasses/AnalyticPluginBase.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Kakaprodo\SystemAnalytic\Lib\BaseClasses;
+
+
+abstract class AnalyticPluginBase
+{
+    /**
+     * can be any a class or an array of key:value
+     * @var string|array|null
+     */
+    public $pluginHandler = [];
+
+    public function __construct($pluginHandler)
+    {
+        $this->pluginHandler = $pluginHandler;
+    }
+
+    /**
+     * load the plugin functionality
+     */
+    abstract public function load();
+}

--- a/src/Lib/BaseClasses/AnalyticPluginBase.php
+++ b/src/Lib/BaseClasses/AnalyticPluginBase.php
@@ -30,4 +30,17 @@ abstract class AnalyticPluginBase
      * load the plugin functionality
      */
     abstract public function load();
+
+    /**
+     * to the registered handler of agiven plugin,
+     * add new one
+     * 
+     * @param string|array|null $newHandlers
+     */
+    public function addHandler($newHandler)
+    {
+        $this->pluginHandler = array_merge((array)$this->pluginHandler, (array) $newHandler);
+
+        return $this;
+    }
 }

--- a/src/Lib/BaseClasses/Traits/HasRegisteredPluginClass.php
+++ b/src/Lib/BaseClasses/Traits/HasRegisteredPluginClass.php
@@ -45,6 +45,6 @@ trait HasRegisteredPluginClass
      */
     public function plugin(): PluginHub
     {
-        return  $this->data->pluginHub = new PluginHub();
+        return  $this->data->pluginHub = new PluginHub($this->data);
     }
 }

--- a/src/Lib/BaseClasses/Traits/HasRegisteredPluginClass.php
+++ b/src/Lib/BaseClasses/Traits/HasRegisteredPluginClass.php
@@ -4,10 +4,13 @@ namespace Kakaprodo\SystemAnalytic\Lib\BaseClasses\Traits;
 
 use Kakaprodo\SystemAnalytic\Lib\AnalyticResponse;
 use Kakaprodo\SystemAnalytic\Lib\Cache\SystemAnalyticCache;
-
+use Kakaprodo\SystemAnalytic\Lib\Data\AnalyticData;
+use Kakaprodo\SystemAnalytic\Lib\Plugins\PluginHub;
 
 /**
  * A trait where to register plugin like: cache, response ...
+ * 
+ * @property AnalyticData $data
  */
 trait HasRegisteredPluginClass
 {
@@ -34,5 +37,14 @@ trait HasRegisteredPluginClass
         $this->cache()->cacheResultIfDoesnotExists($result);
 
         return AnalyticResponse::make($result, $this);
+    }
+
+    /**
+     * The plugin gate on which you can collect data handler for 
+     * any supported plugin
+     */
+    public function plugin(): PluginHub
+    {
+        return  $this->data->pluginHub = new PluginHub();
     }
 }

--- a/src/Lib/Cache/SystemAnalyticCache.php
+++ b/src/Lib/Cache/SystemAnalyticCache.php
@@ -46,6 +46,11 @@ class SystemAnalyticCache
      */
     const NO_CACHE_RESULT = 'NO_CACHE_RESULT';
 
+    /**
+     * default statement for persiting data
+     */
+    const PERSIST_WHEN_SCOPE_IS_INPAST = 'PERSIST_WHEN_SCOPE_IS_INPAST';
+
     public function __construct(AnalyticHandler &$handler)
     {
         $this->handler = &$handler;

--- a/src/Lib/Cache/SystemAnalyticCache.php
+++ b/src/Lib/Cache/SystemAnalyticCache.php
@@ -46,9 +46,9 @@ class SystemAnalyticCache
      */
     const NO_CACHE_RESULT = 'NO_CACHE_RESULT';
 
-    public function __construct(AnalyticHandler $handler)
+    public function __construct(AnalyticHandler &$handler)
     {
-        $this->handler = $handler;
+        $this->handler = &$handler;
 
         $this->supportCaching = config('system-analytic.should_cache_result');
 

--- a/src/Lib/Cache/Traits/HasDataPersistenceTrait.php
+++ b/src/Lib/Cache/Traits/HasDataPersistenceTrait.php
@@ -5,6 +5,7 @@ namespace Kakaprodo\SystemAnalytic\Lib\Cache\Traits;
 use Illuminate\Support\Arr;
 use Kakaprodo\SystemAnalytic\Utilities\Util;
 use Kakaprodo\SystemAnalytic\Lib\AnalyticHandler;
+use Kakaprodo\SystemAnalytic\Lib\Cache\SystemAnalyticCache;
 
 /**
  * @property AnalyticHandler handler
@@ -42,10 +43,17 @@ trait HasDataPersistenceTrait
 
         if ($this->handler->persistResultOfAnyScope) $this->storeResult($result, $shouldRefresh);
 
-        // the @reportScopeIsInPast sets he startDate and the endDate
-        $scopeIsPastPeriod = $this->reportScopeIsInPast();
+        $persistWhen = $this->handler->persistWhen();
 
-        if (!$scopeIsPastPeriod) return;
+        if ($persistWhen === SystemAnalyticCache::PERSIST_WHEN_SCOPE_IS_INPAST) {
+            // the @reportScopeIsInPast sets the startDate and the endDate to the 
+            // current class
+            $scopeIsPastPeriod = $this->reportScopeIsInPast();
+
+            if (!$scopeIsPastPeriod) return;
+        }
+
+        if ($persistWhen !== true) return;
 
         $this->storeResult($result, $shouldRefresh);
     }

--- a/src/Lib/Cache/Traits/HasDataPersistenceTrait.php
+++ b/src/Lib/Cache/Traits/HasDataPersistenceTrait.php
@@ -40,12 +40,12 @@ trait HasDataPersistenceTrait
             if ($this->persistedKeyExists($this->getCacheKey())) return;
         }
 
+        if ($this->handler->persistResultOfAnyScope) $this->storeResult($result, $shouldRefresh);
+
         // the @reportScopeIsInPast sets he startDate and the endDate
         $scopeIsPastPeriod = $this->reportScopeIsInPast();
 
-        if (!$this->handler->persistResultOfAnyScope) {
-            if (!$scopeIsPastPeriod) return;
-        }
+        if (!$scopeIsPastPeriod) return;
 
         $this->storeResult($result, $shouldRefresh);
     }

--- a/src/Lib/Data/Base/AnalyticHandlerRegisterBase.php
+++ b/src/Lib/Data/Base/AnalyticHandlerRegisterBase.php
@@ -38,7 +38,7 @@ abstract class AnalyticHandlerRegisterBase implements AnalyticHandlerRegisterInt
     public static function formValidationRules($request)
     {
         return array_merge(
-            AnalyticData::formValidationRules(),
+            AnalyticData::formValidationRules($request),
             static::requestRules($request)
         );
     }

--- a/src/Lib/Data/Base/AnalyticHandlerRegisterBase.php
+++ b/src/Lib/Data/Base/AnalyticHandlerRegisterBase.php
@@ -3,8 +3,9 @@
 namespace Kakaprodo\SystemAnalytic\Lib\Data\Base;
 
 use Kakaprodo\SystemAnalytic\Utilities\Util;
-use Kakaprodo\SystemAnalytic\Http\Requests\SystemAnalyticRequest;
 use Kakaprodo\SystemAnalytic\Lib\Data\AnalyticData;
+use Kakaprodo\SystemAnalytic\Lib\Plugins\PluginHub;
+use Kakaprodo\SystemAnalytic\Http\Requests\SystemAnalyticRequest;
 use Kakaprodo\SystemAnalytic\Lib\Interfaces\AnalyticHandlerRegisterInterface;
 
 abstract class AnalyticHandlerRegisterBase implements AnalyticHandlerRegisterInterface
@@ -50,6 +51,13 @@ abstract class AnalyticHandlerRegisterBase implements AnalyticHandlerRegisterInt
     public static function requestRules(SystemAnalyticRequest $request): array
     {
         return [];
+    }
+
+    /**
+     * method in which to load plugins
+     */
+    public function loadPlugins(PluginHub $pluginHub)
+    {
     }
 
     public function __get($name)

--- a/src/Lib/Data/Base/DataType.php
+++ b/src/Lib/Data/Base/DataType.php
@@ -31,6 +31,12 @@ abstract class DataType extends CustomData
      */
     public $pluginHub;
 
+    /**
+     * True when the scope type is a custom one defined
+     * in scope plugin
+     */
+    public $scopeHandlerIsFromPlugin = false;
+
     protected function expectedProperties(): array
     {
         return [];

--- a/src/Lib/Data/Base/DataType.php
+++ b/src/Lib/Data/Base/DataType.php
@@ -7,6 +7,7 @@ use Kakaprodo\CustomData\CustomData;
 use Kakaprodo\SystemAnalytic\Utilities\Util;
 use Kakaprodo\CustomData\Exceptions\MissedRequiredPropertyException;
 use Kakaprodo\SystemAnalytic\Lib\Data\Base\AnalyticHandlerRegisterBase;
+use Kakaprodo\SystemAnalytic\Lib\Plugins\PluginHub;
 
 abstract class DataType extends CustomData
 {
@@ -23,6 +24,12 @@ abstract class DataType extends CustomData
      * eg: if scope=today; // value will be Y-m-d: 2023-10-11
      */
     protected $filterValueHub;
+
+    /**
+     * the gate to access to all registered plugins
+     * @var PluginHub 
+     */
+    public $pluginHub;
 
     protected function expectedProperties(): array
     {

--- a/src/Lib/FilterHub/AnalyticBoolFilterHub.php
+++ b/src/Lib/FilterHub/AnalyticBoolFilterHub.php
@@ -15,9 +15,9 @@ class AnalyticBoolFilterHub
     const WITH_TRASHED = 'with_trashed';
     const ONLY_TRASHED = 'only_trashed';
 
-    public function __construct(AnalyticData $data)
+    public function __construct(AnalyticData &$data)
     {
-        $this->data = $data;
+        $this->data = &$data;
     }
 
     public static function apply(AnalyticData $data, $query)

--- a/src/Lib/FilterHub/AnalyticFilterHub.php
+++ b/src/Lib/FilterHub/AnalyticFilterHub.php
@@ -4,7 +4,7 @@ namespace Kakaprodo\SystemAnalytic\Lib\FilterHub;
 
 use Kakaprodo\SystemAnalytic\Utilities\Util;
 use Kakaprodo\SystemAnalytic\Lib\Data\AnalyticData;
-use Kakaprodo\SystemAnalytic\Lib\Data\Base\AnalyticFilterHubBase;
+use Kakaprodo\SystemAnalytic\Lib\BaseClasses\AnalyticFilterHubBase;
 
 /**
  * This class filters the query

--- a/src/Lib/FilterHub/AnalyticScopeValueHub.php
+++ b/src/Lib/FilterHub/AnalyticScopeValueHub.php
@@ -23,7 +23,7 @@ class AnalyticScopeValueHub extends AnalyticFilterHubBase
     protected $endDate = null;
 
     public static function apply(
-        AnalyticData $data,
+        AnalyticData &$data,
     ) {
         if (!$data->scope_type) return null;
 

--- a/src/Lib/FilterHub/AnalyticScopeValueHub.php
+++ b/src/Lib/FilterHub/AnalyticScopeValueHub.php
@@ -4,7 +4,7 @@ namespace Kakaprodo\SystemAnalytic\Lib\FilterHub;
 
 use Kakaprodo\SystemAnalytic\Utilities\Util;
 use Kakaprodo\SystemAnalytic\Lib\Data\AnalyticData;
-use Kakaprodo\SystemAnalytic\Lib\Data\Base\AnalyticFilterHubBase;
+use Kakaprodo\SystemAnalytic\Lib\BaseClasses\AnalyticFilterHubBase;
 
 /**
  * A filter class that detect the value of a named scope type

--- a/src/Lib/Plugins/PluginHub.php
+++ b/src/Lib/Plugins/PluginHub.php
@@ -27,14 +27,16 @@ class PluginHub
     }
 
     /**
-     * Register functionalities that will extend scope or
-     * query filtering feature
+     * Register functionalities that will extend or customize the 
+     * main query scopes
      * 
      * @param string|array payload : can be a class or an array
      */
-    public function scope($payload)
+    public function queryScope($payload)
     {
-        $this->registeredPlugins['scopes'] = new ScopePlugin($payload, $this->data);
+        $this->registeredPlugins['scopes'] = $this->scopes ?
+            $this->scopes->addHandler($payload)
+            : new ScopePlugin($payload, $this->data);
 
         return $this;
     }

--- a/src/Lib/Plugins/PluginHub.php
+++ b/src/Lib/Plugins/PluginHub.php
@@ -2,6 +2,7 @@
 
 namespace Kakaprodo\SystemAnalytic\Lib\Plugins;
 
+use Kakaprodo\SystemAnalytic\Lib\Data\AnalyticData;
 use Kakaprodo\SystemAnalytic\Lib\Plugins\Types\ScopePlugin;
 
 /**
@@ -15,14 +16,25 @@ class PluginHub
     public  $registeredPlugins = [];
 
     /**
+     * The inputed data
+     * @var AnalyticData
+     */
+    protected $data;
+
+    public function __construct(AnalyticData &$data)
+    {
+        $this->data = &$data;
+    }
+
+    /**
      * Register functionalities that will extend scope or
      * query filtering feature
      * 
-     * @param string|array data : can be a class or an array
+     * @param string|array payload : can be a class or an array
      */
-    public function scope($data)
+    public function scope($payload)
     {
-        $this->registeredPlugins['scopes'] = new ScopePlugin($data);
+        $this->registeredPlugins['scopes'] = new ScopePlugin($payload, $this->data);
 
         return $this;
     }

--- a/src/Lib/Plugins/PluginHub.php
+++ b/src/Lib/Plugins/PluginHub.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Kakaprodo\SystemAnalytic\Lib\Plugins;
+
+use Kakaprodo\SystemAnalytic\Lib\Plugins\Types\ScopePlugin;
+
+/**
+ * This class will collect data that will used to load 
+ * specific plugins
+ * 
+ * @property ScopePlugin $scopes
+ */
+class PluginHub
+{
+    public  $registeredPlugins = [];
+
+    /**
+     * Register functionalities that will extend scope or
+     * query filtering feature
+     * 
+     * @param string|array data : can be a class or an array
+     */
+    public function scope($data)
+    {
+        $this->registeredPlugins['scopes'] = new ScopePlugin($data);
+
+        return $this;
+    }
+
+    public function __get($name)
+    {
+        return  $this->registeredPlugins[$name] ?? null;
+    }
+}

--- a/src/Lib/Plugins/Types/ScopePlugin.php
+++ b/src/Lib/Plugins/Types/ScopePlugin.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Kakaprodo\SystemAnalytic\Lib\Plugins\Types;
+
+use ReflectionClass;
+use ReflectionMethod;
+use Kakaprodo\SystemAnalytic\Utilities\Util;
+use Kakaprodo\SystemAnalytic\Lib\Data\AnalyticData;
+use Kakaprodo\SystemAnalytic\Lib\BaseClasses\AnalyticPluginBase;
+
+class ScopePlugin extends AnalyticPluginBase
+{
+    const HANDLER_ARRAY = 'array';
+    const HANDLER_CLASS = 'class';
+
+    public function load()
+    {
+        [$dbQuery, $data] = func_get_args();
+
+        $handlerType = is_array($this->pluginHandler) ? self::HANDLER_ARRAY : self::HANDLER_CLASS;
+
+        $handler = [
+            self::HANDLER_ARRAY => fn () => $this->loadFromArray($dbQuery, $data),
+            self::HANDLER_CLASS => fn () => $this->loadFromClass($dbQuery, $data),
+        ][$handlerType];
+
+        return Util::callFunction($handler);
+    }
+
+    /**
+     * inject the main analytic handler query and the inputs data
+     * to the scope handler
+     */
+    private function loadFromArray($dbQuery, AnalyticData $data)
+    {
+        $scopeHandlers = [];
+
+        foreach ($this->pluginHandler as $scopeName => $handler) {
+            $scopeHandlers[$scopeName] = fn () => $handler($dbQuery, $data);
+        }
+
+        return $scopeHandlers;
+    }
+
+    /**
+     * Convert class methods to modulars then inject db qeuery and the inputed data
+     * to each class method
+     */
+    private function loadFromClass($dbQuery, AnalyticData $data)
+    {
+        $pluginHandler = $this->pluginHandler;
+
+        Util::whenNot(
+            class_exists($pluginHandler),
+            sprintf("Plugin %s not found, make sure registered plugin exist", $pluginHandler)
+        );
+
+
+        $reflection = new ReflectionClass($pluginHandler);
+        $publicMethods = $reflection->getMethods(ReflectionMethod::IS_PUBLIC);
+
+        $scopeHandlers = [];
+        $pluginHandlerClass = new $pluginHandler();
+
+        foreach ($publicMethods as $method) {
+            $scopeHandlers[$method] = fn () => $pluginHandlerClass->{$method}($dbQuery, $data);
+        }
+
+        return $scopeHandlers;
+    }
+}

--- a/src/Skeleton/AnalyticHandlerRegister.php
+++ b/src/Skeleton/AnalyticHandlerRegister.php
@@ -10,14 +10,6 @@ use Kakaprodo\SystemAnalytic\Lib\Data\Base\AnalyticHandlerRegisterBase;
 class AnalyticHandlerRegister extends AnalyticHandlerRegisterBase
 {
     /**
-     * The additional request rules to use in the integrated FormRequest validation
-     */
-    public static function requestRules(SystemAnalyticRequest $request): array
-    {
-        return [];
-    }
-
-    /**
      * Register data that you need to use in your
      * analytic handlers
      */

--- a/src/Utilities/Util.php
+++ b/src/Utilities/Util.php
@@ -98,7 +98,9 @@ class Util
     {
         if (is_callable($myFunction)) return $myFunction(...$args);
 
-        if ($throwableMsg) self::fireErr($throwableMsg)->die();
+        if ($throwableMsg) is_callable($throwableMsg) ?
+            $throwableMsg()
+            : self::fireErr($throwableMsg)->die();
 
         return $myFunction;
     }


### PR DESCRIPTION
# work done
Now you can be able to use your own scopeTypes for your queries by defining them in your handler class

```php
// in handler class
  public function loadPlugins(PluginHub $pluginHub)
    {
        $pluginHub->queryScope([
            'yesterday' => fn ($q, $data) => $q->whereDate('created_at', today()->subDay())
        ]);
    }
``` 
Then to call your custom scope:
```php
AnalyticGate::process([
    'analytic_type' => 'my-handler-name-here',
    'scope_type' => 'yesterday', // we call it here
]);
```